### PR TITLE
Add edit delete option in cuisine

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,3 @@
+class Admin::BaseController < ApplicationController
+  layout "admin"
+end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,6 +1,4 @@
-class Admin::CategoriesController < ApplicationController
-  layout "admin"
-
+class Admin::CategoriesController < Admin::BaseController
   before_action :find_category, only: %i(edit update destroy)
   before_action :update_related_cuisines, only: %i(destroy)
 

--- a/app/controllers/admin/cuisines_controller.rb
+++ b/app/controllers/admin/cuisines_controller.rb
@@ -1,12 +1,12 @@
-class Admin::CuisinesController < ApplicationController
+class Admin::CuisinesController < Admin::BaseController
   before_action :find_cuisine, only: %i(edit update destroy)
   before_action :load_categories, only: %i(new edit)
 
-  layout "admin"
-
   def index
     @q = Cuisine.ransack(params[:q])
-    @pagy, @cuisines = pagy(@q.result(distinct: true),
+    @pagy, @cuisines = pagy(@q
+    .result(distinct: true)
+    .includes(:options, :category).order(created_at: :desc),
                             items: Settings.config.cuisines_per_page)
   end
 

--- a/app/controllers/admin/options_controller.rb
+++ b/app/controllers/admin/options_controller.rb
@@ -1,0 +1,64 @@
+class Admin::OptionsController < Admin::BaseController
+  before_action :find_cuisine
+  before_action :find_option, only: [:destroy, :update, :edit]
+
+  # Your actions here
+  # For example, to create a new option:
+  def new
+    @option = @cuisine.options.build
+  end
+
+  def create
+    @option = @cuisine.options.build option_params
+    if @option.save
+      flash[:success] = t(".success")
+
+    else
+      flash.now[:danger] = t(".fail")
+    end
+    redirect_to edit_admin_cuisine_path(slug: @cuisine.slug)
+  end
+
+  def edit; end
+
+  def update
+    if @option.update(option_params)
+      flash[:success] = t(".success")
+
+    else
+      flash.now[:danger] = t(".fail")
+    end
+    redirect_to edit_admin_cuisine_path(slug: @cuisine.slug)
+  end
+
+  def destroy
+    if @option.destroy
+      flash[:success] = t(".success")
+    else
+      flash[:danger] = t(".fail")
+    end
+    redirect_to edit_admin_cuisine_path(slug: @cuisine.slug)
+  end
+
+  private
+
+  def option_params
+    params.require(:option).permit(:name, :price)
+  end
+
+  def find_cuisine
+    @cuisine = Cuisine.find_by(slug: params[:cuisine_slug])
+    return if @cuisine
+
+    flash[:danger] = t(".not_found")
+    redirect_to admin_cuisines_path
+  end
+
+  def find_option
+    @option = Option.find_by(id: params[:id])
+    return if @option
+
+    flash[:danger] = t(".not_found")
+    redirect_to edit_admin_cuisine_path(slug: @cuisine.slug)
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,6 +1,4 @@
-class Admin::OrdersController < ApplicationController
-  layout "admin"
-
+class Admin::OrdersController < Admin::BaseController
   before_action :find_order, only: %i(update)
 
   def index

--- a/app/views/admin/cuisines/edit.html.erb
+++ b/app/views/admin/cuisines/edit.html.erb
@@ -5,3 +5,14 @@
   </div>
 </div>
 <%= render partial: "admin/shared/cuisine_form"%>
+<div class="card mb-3 mt-5">
+  <div class="card-header">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title"><%= t(".options_list") %></h5>
+      <%= link_to t(".add_option"), new_admin_cuisine_option_path(cuisine_slug: @cuisine.slug), class: "btn btn-primary" %>
+    </div>
+  </div>
+  <div class="card-body">
+    <%= render partial: "admin/shared/option", collection: @cuisine.options %>
+  </div>
+</div>

--- a/app/views/admin/options/edit.html.erb
+++ b/app/views/admin/options/edit.html.erb
@@ -4,7 +4,5 @@
     <%= link_to t(".back"), edit_admin_cuisine_path(slug: @cuisine.slug), class: "btn btn-secondary" %>
   </div>
 </div>
-<%= content_for :button_text do %>
-  <%= t(".submit") %>
-<% end %>
-<%= render partial: "admin/shared/cuisine_form"%>
+<% content_for :custom_path, admin_cuisine_option_path(cuisine_slug: @cuisine.slug, id: @option.id) %>
+<%= render partial: "admin/shared/option_form"%>

--- a/app/views/admin/options/new.html.erb
+++ b/app/views/admin/options/new.html.erb
@@ -4,7 +4,5 @@
     <%= link_to t(".back"), edit_admin_cuisine_path(slug: @cuisine.slug), class: "btn btn-secondary" %>
   </div>
 </div>
-<%= content_for :button_text do %>
-  <%= t(".submit") %>
-<% end %>
-<%= render partial: "admin/shared/cuisine_form"%>
+<% content_for :custom_path, admin_cuisine_options_path(cuisine_slug: @cuisine.slug) %>
+<%= render partial: "admin/shared/option_form"%>

--- a/app/views/admin/shared/_cuisine.html.erb
+++ b/app/views/admin/shared/_cuisine.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= image_tag cuisine_image(cuisine), class: cuisine_image_class(cuisine) , width: 100 %></td>
-  <td><%= link_to cuisine.name, admin_cuisine_path(cuisine) %></td>
+  <td><%= link_to cuisine.name, edit_admin_cuisine_path(slug: cuisine.slug) %></td>
   <td><%= cuisine.category_name %></td>
   <td><%= cuisine.description %></td>
   <td><%= number_to_currency(cuisine.price) %></td>

--- a/app/views/admin/shared/_cuisine_form.html.erb
+++ b/app/views/admin/shared/_cuisine_form.html.erb
@@ -1,11 +1,15 @@
 <%= bootstrap_form_for([:admin, @cuisine]) do |f| %>
   <%= f.alert_message t("admin.shared.cuisine_form.please_fix_errors_below") %>
-  <%= f.text_field :name , label: t("admin.shared.cuisine_form.name") %>
-  <%= f.text_area :description , label: t("admin.shared.cuisine_form.description"), placeholder: t("admin.shared.cuisine_form.description_placeholder") %>
-  <%= f.text_field :price , label: t("admin.shared.cuisine_form.price") %>
-  <%= f.text_field :discount , label: t("admin.shared.cuisine_form.discount") %>
-  <%= f.file_field :image , label: t("admin.shared.cuisine_form.image") %>
-  <%= f.select :category_id, @categories, { label: "Choose a category:" }, { class: "selectpicker" } %>
+  <div class="row">
+    <div class="col"><%= f.text_field :name , label: t("admin.shared.cuisine_form.name") %></div>
+    <div class="col"><%= f.text_field :price , label: t("admin.shared.cuisine_form.price") %></div>
+    <div class="col"><%= f.text_field :discount , label: t("admin.shared.cuisine_form.discount") %></div>
+  </div>
+  <div class="row">
+    <div class="col"><%= f.text_area :description , label: t("admin.shared.cuisine_form.description"), placeholder: t("admin.shared.cuisine_form.description_placeholder") %></div>
+    <div class="col"><%= f.select :category_id, @categories, { label: t(".choose_category") }, { class: "selectpicker" } %></div>
+    <div class="col"><%= f.file_field :image , label: t("admin.shared.cuisine_form.image") %></div>
+  </div>
   <%= f.check_box :available , label: t("admin.shared.cuisine_form.available") %>
   <%= f.submit t("admin.shared.cuisine_form.save"), class: "btn btn-primary", data: { turbo: false } %>
 <% end %>

--- a/app/views/admin/shared/_option.html.erb
+++ b/app/views/admin/shared/_option.html.erb
@@ -1,0 +1,14 @@
+<div class="card mb-3">
+  <div class="card-body">
+    <div class="card-text d-flex justify-content-between">
+      <div class="">
+        <strong class="font-weight-bold"><%= t("admin.shared.option.name") %>:</strong> <%= option.name %><br>
+        <strong class="font-weight-bold"><%= t("admin.shared.option.price") %>:</strong> <%= option.price %><br>
+      </div>
+      <div class="">
+        <%= link_to t("admin.shared.option.edit"), edit_admin_cuisine_option_path(cuisine_slug: option.cuisine.slug, id: option.id), class: "btn btn-primary btn-sm text-white" %>
+        <%= link_to t("admin.shared.option.delete"), admin_cuisine_option_path(cuisine_slug: option.cuisine.slug, id: option.id), data: {"turbo-method": :delete, turbo_confirm: t(".admin.shared.option.are_you_sure")}, class: "btn btn-danger btn-sm text-white" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_option_form.html.erb
+++ b/app/views/admin/shared/_option_form.html.erb
@@ -1,0 +1,6 @@
+<%= bootstrap_form_for([:admin, @option], url: content_for(:custom_path)) do |f| %>
+  <%= f.alert_message t("admin.shared.category_form.please_fix_errors_below") %>
+  <%= f.text_field :name , label: t("admin.shared.option.name") %>
+  <%= f.text_field :price , label: t("admin.shared.option.price") %>
+  <%= f.submit t("admin.shared.option.save"), class: "btn btn-primary", data: { turbo: false } %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,8 @@ en:
         submit: "Update Cuisine"
         back: "Back"
         not_found: "Cuisine not found"
+        add_option: "Add Option"
+        options_list: "Options List"
       create:
         success: "Cuisine created successfully"
         fail: "Cuisine created failed"
@@ -196,6 +198,22 @@ en:
       update:
         success: "Order updated successfully"
         fail: "Order updated fail"
+    options:
+      create:
+        success: "Option created successfully"
+        fail: "Option created failed"
+      update:
+        success: "Option updated successfully"
+        fail: "Option updated failed"
+      destroy:
+        success: "Option deleted successfully"
+        fail: "Option deleted failed"
+      edit:
+        title: "Edit Option"
+        back: "Back"
+      new:
+        title: "New Option"
+        back: "Back"
     shared:
       cuisine:
         delete: "Delete"
@@ -244,6 +262,13 @@ en:
         search_by_phone: "Search by phone"
         search_by_address: "Search by address"
         search_by_status: "Search by status"
+      option:
+        name: "Name"
+        price: "Price"
+        edit: "Edit"
+        delete: "Delete"
+        are_you_sure: "Are you sure?"
+        save: "Save"
   orders:
     filter_form:
       status: "Status"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -146,6 +146,8 @@ vi:
         submit: "Cập nhật Cuisine"
         back: "Quay lại"
         not_found: "Không tìm thấy cuisine"
+        add_option: "Thêm tùy chọn"
+        options_list: "Danh sách tùy chọn"
       create:
         success: "Cuisine được tạo thành công"
         fail: "Tạo cuisine thất bại"
@@ -203,6 +205,22 @@ vi:
       update:
         success: "Cập nhật thành công"
         fail: "Cập nhật thất bại"
+    options:
+      create:
+        success: "Tạo option thành công"
+        fail: "Tạo option thất bại"
+      update:
+        success: "Cập nhật option thành công"
+        fail: "Cập nhật option thất bại"
+      destroy:
+        success: "Xóa option thành công"
+        fail: "Xóa option thất bại"
+      edit:
+        title: "Chỉnh sửa option"
+        back: "Quay lại"
+      new:
+        title: "Tạo option mới"
+        back: "Quay lại"
     shared:
       cuisine:
         edit: "Chỉnh sửa"
@@ -254,6 +272,13 @@ vi:
         search_by_status: "Tìm kiếm theo trạng thái"
         search_by_min_total: "Tìm kiếm theo tổng tối thiểu"
         search_by_max_total: "Tìm kiếm theo tổng tối đa"
+      option:
+        name: "Tên"
+        price: "Giá"
+        edit: "Chỉnh sửa"
+        delete: "Xóa"
+        are_you_sure: "Bạn có chắc chắn không?"
+        save: "Lưu"
   orders:
     filter_form:
       status: "Trạng thái"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
     resources :categories, param: :slug, only: :show
     resources :cuisines, param: :slug, only: %i(index show)
     namespace :admin do
-      resources :cuisines, param: :slug, except: :show
+      resources :cuisines, param: :slug, except: :show do
+        resources :options, only: %i(create new destroy edit update)
+      end
       resources :categories, param: :slug
       resources :orders, only: %i(index show destroy update)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,7 +83,7 @@ cuisine6 = Cuisine.create(
 )
 cuisine6.image.attach(io: File.open(Rails.root.join('./app/assets/images', 'image.jpg')), filename: 'image.jpg')
 
-#Add more cuisines with unique images as needed
+# Add more cuisines with unique images as needed
 first_name = "Admin"
 last_name = "Admin"
 email = "admin@gmail.com"


### PR DESCRIPTION
## Related Tickets
- ticket redmine
- https://edu-redmine.sun-asterisk.vn/issues/68580?issue_count=14&issue_position=1&next_issue_id=67363

## WHAT (optional)
- Thêm chức năng thêm xóa sửa các option cho cuisine

## HOW
- Thêm giao diện và logic vào trang edit cuisine

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![Screenshot from 2023-09-14 20-07-02](https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/83919782/bd9a6519-8423-4bdf-839f-7bd05dc59485)
![Screenshot from 2023-09-14 20-05-59](https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/83919782/796a1191-49b7-454b-a871-8b06368c10aa)
![Screenshot from 2023-09-14 20-05-43](https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/83919782/6a1419d4-8bde-4fdb-a15c-bab859eb7a95)



## Notes (Kiến thức tìm hiểu thêm)
