### PR TITLE
fix: fix err blocking host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.hosts <<  "foodrink.kien2572001.tech"
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
## Related Tickets
- ticket redmine

## WHAT (optional)
- Domain bị chặn do chưa mở khóa domain trong config của Rails

## HOW
- Sửa config
## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
<img width="953" alt="image" src="https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/83919782/9b308eed-4fff-4430-b015-10e157230026">


## Notes (Kiến thức tìm hiểu thêm)
