### PR TITLE
Fix not display pagination when not enough cuisine

### DIFF
--- a/app/controllers/cuisines_controller.rb
+++ b/app/controllers/cuisines_controller.rb
@@ -4,10 +4,12 @@ class CuisinesController < ApplicationController
     @q = Cuisine.ransack(params[:q])
     if params[:q].present?
       @pagy, @cuisines = pagy(@q.result(distinct: true),
-                              items: Settings.config.cuisines_per_page)
+                              items: Settings.config.pagination
+                              .cuisines_per_page)
     else
       @pagy, @cuisines = pagy(Cuisine.order_by_created_at,
-                              items: Settings.config.cuisines_per_page)
+                              items: Settings.config.pagination
+                              .cuisines_per_page)
     end
   end
 

--- a/app/helpers/cuisine_helper.rb
+++ b/app/helpers/cuisine_helper.rb
@@ -10,4 +10,8 @@ module CuisineHelper
   def cuisine_image_class cuisine
     cuisine.available? ? "cuisine-image" : "cuisine-image-not-available"
   end
+
+  def display_pagination? cuisines
+    cuisines.count > Settings.config.pagination.cuisines_per_page
+  end
 end

--- a/app/views/cuisines/index.html.erb
+++ b/app/views/cuisines/index.html.erb
@@ -34,11 +34,15 @@
   <div class="container">
     <div class="row">
       <% if @cuisines.any? %>
-      <%== pagy_bootstrap_nav(@pagy) %>
+        <% if display_pagination? @cuisines %>
+          <%== pagy_bootstrap_nav(@pagy) %>
+        <% end %>
         <%= render @cuisines %>
-      <%== pagy_bootstrap_nav(@pagy) %>
+        <% if display_pagination? @cuisines %>
+          <%== pagy_bootstrap_nav(@pagy) %>
+        <% end %>
       <% else %>
-        <p>No cuisines found.</p>
+        <p><%= t "cuisine.no_found" %></p>
       <% end %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
     must_be_a_PNG_JPG_JPEG: "must be a PNG, JPG, JPEG"
     out_of_stock: "Out of stock"
     available: "Available"
+    no_found: "No cuisines found"
   category:
     no_have: "Don't have this category"
   sessions:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -118,6 +118,7 @@ vi:
     must_be_a_PNG_JPG_JPEG: "phai la PNG, JPG, JPEG"
     out_of_stock: "Het hang"
     available: "Con hang"
+    no_found: "Khong co mon an nao"
   category:
     no_have: "Khong co danh muc nay"
   sessions:


### PR DESCRIPTION
## Related Tickets
- ticket redmine

## WHAT (optional)
- Em sửa chỗ hiển thị cuisine, khi không đủ số lượng phân trang thì không phân trang nữa

## HOW

## WHY (optional)

## Evidence (Screenshot or Video)
![image](https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/94180098/720d7345-9ffe-4f6e-be0d-d3b1a45e283b)
![image](https://github.com/awesome-academy/ruby_naitei19_food_drink_management/assets/94180098/e1c8f34f-ef5c-4101-b23f-30d22ff5f0b8)


## Notes (Kiến thức tìm hiểu thêm)
